### PR TITLE
changed the cell in step1 to get only datetime

### DIFF
--- a/examples/trip_fare_prediction_model_1/trip_fare_prediction_1.ipynb
+++ b/examples/trip_fare_prediction_model_1/trip_fare_prediction_1.ipynb
@@ -573,7 +573,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!date -u +'\"pickup_datetime\":\"%Y-%m-%d %H:%M:%S\", \"hour_of_day\":%H, \"calendar_day\":\"%Y-%m-%d\"'"
+    "!date -u +'\"pickup_datetime\":\"%Y-%m-%d %H:%M:%S\"'"
    ]
   },
   {


### PR DESCRIPTION
In step 1 of the tutorial we only need pickup_datetime as a feature in curl for running predictions, thus removing the extra part which fetches calendar_day and hour_of_day.